### PR TITLE
Bump qs 6.15.0 → 6.15.2 (DoS fix, #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mousetrap": "1.6.5",
     "normalize.css": "8.0.1",
     "prop-types": "15.8.1",
-    "qs": "6.15.0",
+    "qs": "6.15.2",
     "rdndmb-html5-to-touch": "8.1.2",
     "react": "18.3.1",
     "react-addons-shallow-compare": "15.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5282,10 +5282,10 @@ punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+qs@6.15.2:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## Summary
Fixes #8. Bumps the direct `qs` dependency from `6.15.0` → `6.15.2` to resolve a DoS crash via `qs.stringify` (yarn audit advisory 1109574).

## Changes
- `package.json`: `"qs": "6.15.0"` → `"6.15.2"`
- `yarn.lock`: re-resolved via `yarn install`

## Verification
- `yarn install` succeeded
- `yarn audit` no longer flags `qs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)