### PR TITLE
Bump Swashbuckle.AspNetCore 10.2.2 -> 10.2.3

### DIFF
--- a/src/NzbDrone.Host/Sonarr.Host.csproj
+++ b/src/NzbDrone.Host/Sonarr.Host.csproj
@@ -6,7 +6,7 @@
 	<ItemGroup>
 		<PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
 		<PackageReference Include="DryIoc.dll" Version="5.4.3" />
 		<PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />

--- a/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
+++ b/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="5.2.2" />
     <PackageReference Include="NLog" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Sonarr.Core.csproj" />

--- a/src/Sonarr.Api.V5/Sonarr.Api.V5.csproj
+++ b/src/Sonarr.Api.V5/Sonarr.Api.V5.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="FluentValidation" Version="9.5.4" />
 		<PackageReference Include="Ical.Net" Version="5.2.2" />
 		<PackageReference Include="NLog" Version="5.5.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\NzbDrone.Core\Sonarr.Core.csproj" />


### PR DESCRIPTION
## Summary

Patch bump of `Swashbuckle.AspNetCore` `10.2.2 → 10.2.3` across all three references:

- `src/NzbDrone.Host/Sonarr.Host.csproj` — `.SwaggerGen`
- `src/Sonarr.Api.V3/Sonarr.Api.V3.csproj` — `.Annotations`
- `src/Sonarr.Api.V5/Sonarr.Api.V5.csproj` — `.Annotations`

Patch release, no breaking changes expected.

## Verification

- Confirmed `10.2.3` is published on NuGet for both packages
- `dotnet restore` succeeds across all projects
- Full `Sonarr.Host` build chain compiles clean (0 warnings / 0 errors)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)