### PR TITLE
Update test toolchain: Microsoft.NET.Test.Sdk, Moq, NUnit (#19)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -121,7 +121,7 @@
   <ItemGroup Condition="'$(TestProject)'=='true'">
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="8.0.0" />

--- a/src/NzbDrone.Core.Test/SeriesStatsTests/SeriesStatisticsServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/SeriesStatsTests/SeriesStatisticsServiceFixture.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Test.SeriesStatsTests
                     LastViewedAtString = DateTime.UtcNow.AddDays(-2).ToString("O")
                 });
 
-            var result = Subject.SeriesStatistics(12);
+            var result = Subject.SeriesStatistics(12, 1);
 
             result.WatchedOnPlex.Should().BeTrue();
             result.NeverWatchedOnPlex.Should().BeFalse();
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Test.SeriesStatsTests
                     SeriesId = 15
                 });
 
-            var result = Subject.SeriesStatistics(15);
+            var result = Subject.SeriesStatistics(15, 1);
 
             result.WatchedOnPlex.Should().BeFalse();
             result.NeverWatchedOnPlex.Should().BeTrue();

--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NLog" Version="5.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #19. Brings the test-toolchain NuGet packages up to date. All changes are test-only — no production code or runtime impact.

| Package | Before | After | Notes |
|---------|--------|-------|-------|
| `Microsoft.NET.Test.Sdk` | 17.10.0 | 17.14.1 | latest 17.x; stayed on the 17 line per the issue's "17.13+" target rather than the major 18.x jump |
| `Moq` | 4.18.4 | 4.20.72 | |
| `NUnit` | 4.6.0* | 4.6.1 | *only `Sonarr.Test.Common` lagged at 4.6.0; aligned to the 4.6.1 already declared centrally |
| `NUnit3TestAdapter` | 6.2.0 | 6.2.0 | already latest — no change |

No Moq 4.20 API deprecations surfaced: the solution builds clean with `TreatWarningsAsErrors` and **0 warnings**.

## Extra fix (pre-existing, unrelated to #19)

While running the suite I hit a pre-existing compile break on `production` that had nothing to do with the toolchain bump: `SeriesStatisticsServiceFixture` still called the old single-arg `SeriesStatistics(int)` overload, but the service now requires `SeriesStatistics(int seriesId, int qualityProfileId)`. This broke the `Core.Test` build regardless of package versions. Fixed minimally (added a profile id) so the suite compiles — behaviour is unchanged since the `IQualityProfileService.Get` mock returns null by default and `SortQualities` tolerates a null profile.

## Verification

Built the full solution (`dotnet build Sonarr.sln`) and ran the Moq-using unit suites:

| Suite | Result |
|-------|--------|
| Core.Test | 5127 passed, 0 failed, 28 skipped |
| Common.Test | 591 passed, 0 failed, 39 skipped |
| Host.Test | 10 passed, 0 failed, 4 skipped |
| Api.Test | 21 passed, 0 failed |
| Update.Test | 17 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)