### PR TITLE
Upgrade FluentValidation 9.5.4 → 12.1.1 (#15)

### DIFF
--- a/src/NzbDrone.Core.Test/TvTests/SeriesTitleSlugValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/SeriesTitleSlugValidatorFixture.cs
@@ -11,7 +11,7 @@ using NzbDrone.Test.Common;
 namespace NzbDrone.Core.Test.TvTests
 {
     [TestFixture]
-    public class SeriesTitleSlugValidatorFixture : CoreTest<SeriesTitleSlugValidator>
+    public class SeriesTitleSlugValidatorFixture : CoreTest<SeriesTitleSlugValidator<Series>>
     {
         private List<Series> _series;
         private TestValidator<Series> _validator;

--- a/src/NzbDrone.Core.Test/ValidationTests/SystemFolderValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/ValidationTests/SystemFolderValidatorFixture.cs
@@ -11,7 +11,7 @@ using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.ValidationTests
 {
-    public class SystemFolderValidatorFixture : CoreTest<SystemFolderValidator>
+    public class SystemFolderValidatorFixture : CoreTest<SystemFolderValidator<Series>>
     {
         private TestValidator<Series> _validator;
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentDirectoryValidator.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentDirectoryValidator.cs
@@ -13,9 +13,9 @@ namespace NzbDrone.Core.Download.Clients.rTorrent
 
     public class RTorrentDirectoryValidator : AbstractValidator<RTorrentSettings>, IRTorrentDirectoryValidator
     {
-        public RTorrentDirectoryValidator(RootFolderValidator rootFolderValidator,
-                                          PathExistsValidator pathExistsValidator,
-                                          MappedNetworkDriveValidator mappedNetworkDriveValidator)
+        public RTorrentDirectoryValidator(RootFolderValidator<RTorrentSettings> rootFolderValidator,
+                                          PathExistsValidator<RTorrentSettings> pathExistsValidator,
+                                          MappedNetworkDriveValidator<RTorrentSettings> mappedNetworkDriveValidator)
         {
             RuleFor(c => c.TvDirectory).Cascade(CascadeMode.Stop)
                 .IsValidPath()

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .IsValidPath()
-                .SetValidator(new SystemFolderValidator())
+                .SetValidator(new SystemFolderValidator<CustomScriptSettings>())
                 .WithMessage("Must not be a descendant of '{systemFolder}'");
 
             RuleFor(c => c.Arguments)

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -19,67 +19,69 @@ namespace NzbDrone.Core.Organizer
 
         public static IRuleBuilderOptions<T, string> ValidEpisodeFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new ValidStandardEpisodeFormatValidator());
+            return ruleBuilder.SetValidator(new ValidStandardEpisodeFormatValidator<T>());
         }
 
         public static IRuleBuilderOptions<T, string> ValidDailyEpisodeFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new ValidDailyEpisodeFormatValidator());
+            return ruleBuilder.SetValidator(new ValidDailyEpisodeFormatValidator<T>());
         }
 
         public static IRuleBuilderOptions<T, string> ValidAnimeEpisodeFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new ValidAnimeEpisodeFormatValidator());
+            return ruleBuilder.SetValidator(new ValidAnimeEpisodeFormatValidator<T>());
         }
 
         public static IRuleBuilderOptions<T, string> ValidSeriesFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.SeriesTitleRegex)).WithMessage("Must contain series title");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator<T>(FileNameBuilder.SeriesTitleRegex)).WithMessage("Must contain series title");
         }
 
         public static IRuleBuilderOptions<T, string> ValidSeasonFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(SeasonFolderRegex)).WithMessage("Must contain season number");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator<T>(SeasonFolderRegex)).WithMessage("Must contain season number");
         }
 
         public static IRuleBuilderOptions<T, string> ValidSpecialsFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new FilteredSubfolderValidator());
+            return ruleBuilder.SetValidator(new FilteredSubfolderValidator<T>());
         }
 
         public static IRuleBuilderOptions<T, string> ValidCustomColonReplacement<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new IllegalColonCharactersValidator());
+            ruleBuilder.SetValidator(new IllegalColonCharactersValidator<T>());
 
-            return ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            return ruleBuilder.SetValidator(new IllegalCharactersValidator<T>());
         }
     }
 
-    public class ValidStandardEpisodeFormatValidator : PropertyValidator
+    public class ValidStandardEpisodeFormatValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Must contain season and episode numbers OR Original Title";
+        public override string Name => "ValidStandardEpisodeFormatValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain season and episode numbers OR Original Title";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue is not string value)
+            if (value == null)
             {
                 return false;
             }
@@ -90,13 +92,15 @@ namespace NzbDrone.Core.Organizer
         }
     }
 
-    public class ValidDailyEpisodeFormatValidator : PropertyValidator
+    public class ValidDailyEpisodeFormatValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Must contain Air Date OR Season and Episode OR Original Title";
+        public override string Name => "ValidDailyEpisodeFormatValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain Air Date OR Season and Episode OR Original Title";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue is not string value)
+            if (value == null)
             {
                 return false;
             }
@@ -108,14 +112,16 @@ namespace NzbDrone.Core.Organizer
         }
     }
 
-    public class ValidAnimeEpisodeFormatValidator : PropertyValidator
+    public class ValidAnimeEpisodeFormatValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() =>
+        public override string Name => "ValidAnimeEpisodeFormatValidator";
+
+        protected override string GetDefaultMessageTemplate(string errorCode) =>
             "Must contain Absolute Episode number OR Season and Episode OR Original Title";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue is not string value)
+            if (value == null)
             {
                 return false;
             }
@@ -127,15 +133,16 @@ namespace NzbDrone.Core.Organizer
         }
     }
 
-    public class IllegalCharactersValidator : PropertyValidator
+    public class IllegalCharactersValidator<T> : PropertyValidator<T, string>
     {
         private static readonly char[] InvalidPathChars = Path.GetInvalidPathChars();
 
-        protected override string GetDefaultMessageTemplate() => "Contains illegal characters: {InvalidCharacters}";
+        public override string Name => "IllegalCharactersValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Contains illegal characters: {InvalidCharacters}";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            var value = context.PropertyValue as string;
             if (value.IsNullOrWhiteSpace())
             {
                 return true;
@@ -153,16 +160,16 @@ namespace NzbDrone.Core.Organizer
         }
     }
 
-    public class IllegalColonCharactersValidator : PropertyValidator
+    public class IllegalColonCharactersValidator<T> : PropertyValidator<T, string>
     {
         private static readonly string[] InvalidPathChars = FileNameBuilder.BadCharacters.Concat(new[] { ":" }).ToArray();
 
-        protected override string GetDefaultMessageTemplate() => "Contains illegal characters: {InvalidCharacters}";
+        public override string Name => "IllegalColonCharactersValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Contains illegal characters: {InvalidCharacters}";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            var value = context.PropertyValue as string;
-
             if (value.IsNullOrWhiteSpace())
             {
                 return true;
@@ -180,16 +187,16 @@ namespace NzbDrone.Core.Organizer
         }
     }
 
-    public class FilteredSubfolderValidator : PropertyValidator
+    public class FilteredSubfolderValidator<T> : PropertyValidator<T, string>
     {
         private static readonly char[] InvalidPathChars = Path.GetInvalidPathChars();
 
-        protected override string GetDefaultMessageTemplate() => "Matches excluded subfolder pattern: {FilteredSubfolders}";
+        public override string Name => "FilteredSubfolderValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Matches excluded subfolder pattern: {FilteredSubfolders}";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            var value = context.PropertyValue as string;
-
             if (value.IsNullOrWhiteSpace())
             {
                 return true;

--- a/src/NzbDrone.Core/Profiles/Delay/DelayProfileTagInUseValidator.cs
+++ b/src/NzbDrone.Core/Profiles/Delay/DelayProfileTagInUseValidator.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Profiles.Delay
 {
-    public class DelayProfileTagInUseValidator : PropertyValidator
+    public class DelayProfileTagInUseValidator<T> : PropertyValidator<T, HashSet<int>>
     {
         private readonly IDelayProfileService _delayProfileService;
 
@@ -14,24 +15,21 @@ namespace NzbDrone.Core.Profiles.Delay
             _delayProfileService = delayProfileService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "One or more tags is used in another profile";
+        public override string Name => "DelayProfileTagInUseValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "One or more tags is used in another profile";
+
+        public override bool IsValid(ValidationContext<T> context, HashSet<int> value)
         {
-            if (context.PropertyValue == null)
+            if (value == null || value.Empty())
             {
                 return true;
             }
 
-            dynamic instance = context.ParentContext.InstanceToValidate;
+            dynamic instance = context.InstanceToValidate;
             var instanceId = (int)instance.Id;
 
-            if (context.PropertyValue is not HashSet<int> collection || collection.Empty())
-            {
-                return true;
-            }
-
-            return _delayProfileService.All().None(d => d.Id != instanceId && d.Tags.Intersect(collection).Any());
+            return _delayProfileService.All().None(d => d.Id != instanceId && d.Tags.Intersect(value).Any());
         }
     }
 }

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="FluentMigrator.Runner.Core" Version="8.0.1" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="8.0.1" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="8.0.1" />
-    <PackageReference Include="FluentValidation" Version="9.5.4" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NLog" Version="5.5.1" />

--- a/src/NzbDrone.Core/Tv/AddSeriesValidator.cs
+++ b/src/NzbDrone.Core/Tv/AddSeriesValidator.cs
@@ -11,10 +11,10 @@ namespace NzbDrone.Core.Tv
 
     public class AddSeriesValidator : AbstractValidator<Series>, IAddSeriesValidator
     {
-        public AddSeriesValidator(RootFolderValidator rootFolderValidator,
-                                  SeriesPathValidator seriesPathValidator,
-                                  SeriesAncestorValidator seriesAncestorValidator,
-                                  SeriesTitleSlugValidator seriesTitleSlugValidator)
+        public AddSeriesValidator(RootFolderValidator<Series> rootFolderValidator,
+                                  SeriesPathValidator<Series> seriesPathValidator,
+                                  SeriesAncestorValidator<Series> seriesAncestorValidator,
+                                  SeriesTitleSlugValidator<Series> seriesTitleSlugValidator)
         {
             RuleFor(c => c.Path).Cascade(CascadeMode.Stop)
                 .IsValidPath()

--- a/src/NzbDrone.Core/Tv/SeriesTitleSlugValidator.cs
+++ b/src/NzbDrone.Core/Tv/SeriesTitleSlugValidator.cs
@@ -1,10 +1,11 @@
-﻿using System.Linq;
+using System.Linq;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Tv
 {
-    public class SeriesTitleSlugValidator : PropertyValidator
+    public class SeriesTitleSlugValidator<T> : PropertyValidator<T, string>
     {
         private readonly ISeriesService _seriesService;
 
@@ -13,23 +14,24 @@ namespace NzbDrone.Core.Tv
             _seriesService = seriesService;
         }
 
-        protected override string GetDefaultMessageTemplate() =>
+        public override string Name => "SeriesTitleSlugValidator";
+
+        protected override string GetDefaultMessageTemplate(string errorCode) =>
             "Title slug '{slug}' is in use by series '{seriesTitle}'. Check the FAQ for more information";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
-            dynamic instance = context.ParentContext.InstanceToValidate;
+            dynamic instance = context.InstanceToValidate;
             var instanceId = (int)instance.Id;
-            var slug = context.PropertyValue.ToString();
 
             var conflictingSeries = _seriesService.GetAllSeries()
                                                   .FirstOrDefault(s => s.TitleSlug.IsNotNullOrWhiteSpace() &&
-                                                              s.TitleSlug.Equals(context.PropertyValue.ToString()) &&
+                                                              s.TitleSlug.Equals(value) &&
                                                               s.Id != instanceId);
 
             if (conflictingSeries == null)
@@ -37,7 +39,7 @@ namespace NzbDrone.Core.Tv
                 return true;
             }
 
-            context.MessageFormatter.AppendArgument("slug", slug);
+            context.MessageFormatter.AppendArgument("slug", value);
             context.MessageFormatter.AppendArgument("seriesTitle", conflictingSeries.Title);
 
             return false;

--- a/src/NzbDrone.Core/Validation/DownloadClientExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/DownloadClientExistsValidator.cs
@@ -1,9 +1,10 @@
-﻿using FluentValidation.Validators;
+using FluentValidation;
+using FluentValidation.Validators;
 using NzbDrone.Core.Download;
 
 namespace NzbDrone.Core.Validation
 {
-    public class DownloadClientExistsValidator : PropertyValidator
+    public class DownloadClientExistsValidator<T> : PropertyValidator<T, int>
     {
         private readonly IDownloadClientFactory _downloadClientFactory;
 
@@ -12,16 +13,18 @@ namespace NzbDrone.Core.Validation
             _downloadClientFactory = downloadClientFactory;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Download Client does not exist";
+        public override string Name => "DownloadClientExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Download Client does not exist";
+
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
-            if (context?.PropertyValue == null || (int)context.PropertyValue == 0)
+            if (value == 0)
             {
                 return true;
             }
 
-            return _downloadClientFactory.Exists((int)context.PropertyValue);
+            return _downloadClientFactory.Exists(value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/FolderChmodValidator.cs
+++ b/src/NzbDrone.Core/Validation/FolderChmodValidator.cs
@@ -1,9 +1,10 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 
 namespace NzbDrone.Core.Validation
 {
-    public class FolderChmodValidator : PropertyValidator
+    public class FolderChmodValidator<T> : PropertyValidator<T, string>
     {
         private readonly IDiskProvider _diskProvider;
 
@@ -12,16 +13,18 @@ namespace NzbDrone.Core.Validation
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Must contain a valid Unix permissions octal";
+        public override string Name => "FolderChmodValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain a valid Unix permissions octal";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            return _diskProvider.IsValidFolderPermissionMask(context.PropertyValue.ToString());
+            return _diskProvider.IsValidFolderPermissionMask(value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/FolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/FolderValidator.cs
@@ -1,23 +1,26 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Validation
 {
-    public class FolderValidator : PropertyValidator
+    public class FolderValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid Path: '{path}'";
+        public override string Name => "FolderValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Invalid Path: '{path}'";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return context.PropertyValue.ToString().IsPathValid(PathValidationType.CurrentOs);
+            return value.IsPathValid(PathValidationType.CurrentOs);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/FileExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/FileExistsValidator.cs
@@ -1,9 +1,10 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class FileExistsValidator : PropertyValidator
+    public class FileExistsValidator<T> : PropertyValidator<T, string>
     {
         private readonly IDiskProvider _diskProvider;
 
@@ -12,18 +13,20 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "File '{file}' does not exist";
+        public override string Name => "FileExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "File '{file}' does not exist";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            context.MessageFormatter.AppendArgument("file", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("file", value);
 
-            return _diskProvider.FileExists(context.PropertyValue.ToString());
+            return _diskProvider.FileExists(value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/FolderWritableValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/FolderWritableValidator.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class FolderWritableValidator : PropertyValidator
+    public class FolderWritableValidator<T> : PropertyValidator<T, string>
     {
         private readonly IDiskProvider _diskProvider;
 
@@ -13,19 +14,21 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Folder '{path}' is not writable by user '{user}'";
+        public override string Name => "FolderWritableValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Folder '{path}' is not writable by user '{user}'";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
             context.MessageFormatter.AppendArgument("user", Environment.UserName);
 
-            return _diskProvider.FolderWritable(context.PropertyValue.ToString());
+            return _diskProvider.FolderWritable(value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/MappedNetworkDriveValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/MappedNetworkDriveValidator.cs
@@ -1,12 +1,13 @@
-﻿using System.IO;
+using System.IO;
 using System.Text.RegularExpressions;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class MappedNetworkDriveValidator : PropertyValidator
+    public class MappedNetworkDriveValidator<T> : PropertyValidator<T, string>
     {
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IDiskProvider _diskProvider;
@@ -19,11 +20,13 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Mapped Network Drive and Windows Service";
+        public override string Name => "MappedNetworkDriveValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Mapped Network Drive and Windows Service";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
@@ -38,14 +41,12 @@ namespace NzbDrone.Core.Validation.Paths
                 return true;
             }
 
-            var path = context.PropertyValue.ToString();
-
-            if (!DriveRegex.IsMatch(path))
+            if (!DriveRegex.IsMatch(value))
             {
                 return true;
             }
 
-            var mount = _diskProvider.GetMount(path);
+            var mount = _diskProvider.GetMount(value);
 
             return mount is not { DriveType: DriveType.Network };
         }

--- a/src/NzbDrone.Core/Validation/Paths/PathExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/PathExistsValidator.cs
@@ -1,9 +1,10 @@
-﻿using FluentValidation.Validators;
+﻿using FluentValidation;
+using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class PathExistsValidator : PropertyValidator
+    public class PathExistsValidator<T> : PropertyValidator<T, string>
     {
         private readonly IDiskProvider _diskProvider;
 
@@ -12,18 +13,20 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' does not exist";
+        public override string Name => "PathExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' does not exist";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return _diskProvider.FolderExists(context.PropertyValue.ToString());
+            return _diskProvider.FolderExists(value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/PathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/PathValidator.cs
@@ -9,24 +9,26 @@ namespace NzbDrone.Core.Validation.Paths
     {
         public static IRuleBuilderOptions<T, string> IsValidPath<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new PathValidator());
+            return ruleBuilder.SetValidator(new PathValidator<T>());
         }
     }
 
-    public class PathValidator : PropertyValidator
+    public class PathValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid Path: '{path}'";
+        public override string Name => "PathValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Invalid Path: '{path}'";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return context.PropertyValue.ToString().IsPathValid(PathValidationType.CurrentOs);
+            return value.IsPathValid(PathValidationType.CurrentOs);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/RecycleBinValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RecycleBinValidator.cs
@@ -1,10 +1,11 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class RecycleBinValidator : PropertyValidator
+    public class RecycleBinValidator<T> : PropertyValidator<T, string>
     {
         private readonly IConfigService _configService;
 
@@ -13,28 +14,29 @@ namespace NzbDrone.Core.Validation.Paths
             _configService = configService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' is {relationship} configured recycle bin folder";
+        public override string Name => "RecycleBinValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' is {relationship} configured recycle bin folder";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
             var recycleBin = _configService.RecycleBin;
 
-            if (context.PropertyValue == null || recycleBin.IsNullOrWhiteSpace())
+            if (value == null || recycleBin.IsNullOrWhiteSpace())
             {
                 return true;
             }
 
-            var folder = context.PropertyValue.ToString();
-            context.MessageFormatter.AppendArgument("path", folder);
+            context.MessageFormatter.AppendArgument("path", value);
 
-            if (recycleBin.PathEquals(folder))
+            if (recycleBin.PathEquals(value))
             {
                 context.MessageFormatter.AppendArgument("relationship", "set to");
 
                 return false;
             }
 
-            if (recycleBin.IsParentPath(folder))
+            if (recycleBin.IsParentPath(value))
             {
                 context.MessageFormatter.AppendArgument("relationship", "child of");
 

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderAncestorValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderAncestorValidator.cs
@@ -1,11 +1,12 @@
 using System.Linq;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class RootFolderAncestorValidator : PropertyValidator
+    public class RootFolderAncestorValidator<T> : PropertyValidator<T, string>
     {
         private readonly IRootFolderService _rootFolderService;
 
@@ -14,18 +15,20 @@ namespace NzbDrone.Core.Validation.Paths
             _rootFolderService = rootFolderService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' is an ancestor of an existing root folder";
+        public override string Name => "RootFolderAncestorValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' is an ancestor of an existing root folder";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return !_rootFolderService.All().Any(s => context.PropertyValue.ToString().IsParentPath(s.Path));
+            return !_rootFolderService.All().Any(s => value.IsParentPath(s.Path));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderExistsValidator.cs
@@ -1,11 +1,12 @@
-﻿using FluentValidation.Validators;
+using FluentValidation;
+using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class RootFolderExistsValidator : PropertyValidator
+    public class RootFolderExistsValidator<T> : PropertyValidator<T, string>
     {
         private readonly IRootFolderService _rootFolderService;
 
@@ -14,13 +15,15 @@ namespace NzbDrone.Core.Validation.Paths
             _rootFolderService = rootFolderService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Root folder '{path}' does not exist";
+        public override string Name => "RootFolderExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Root folder '{path}' does not exist";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue?.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return context.PropertyValue == null || _rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(context.PropertyValue.ToString()));
+            return value == null || _rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(value));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -5,7 +6,7 @@ using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class RootFolderValidator : PropertyValidator
+    public class RootFolderValidator<T> : PropertyValidator<T, string>
     {
         private readonly IRootFolderService _rootFolderService;
 
@@ -14,18 +15,20 @@ namespace NzbDrone.Core.Validation.Paths
             _rootFolderService = rootFolderService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' is already configured as a root folder";
+        public override string Name => "RootFolderValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' is already configured as a root folder";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return !_rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(context.PropertyValue.ToString()));
+            return !_rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(value));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesAncestorValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesAncestorValidator.cs
@@ -1,11 +1,12 @@
 using System.Linq;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class SeriesAncestorValidator : PropertyValidator
+    public class SeriesAncestorValidator<T> : PropertyValidator<T, string>
     {
         private readonly ISeriesService _seriesService;
 
@@ -14,18 +15,20 @@ namespace NzbDrone.Core.Validation.Paths
             _seriesService = seriesService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' is an ancestor of an existing series";
+        public override string Name => "SeriesAncestorValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' is an ancestor of an existing series";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            return !_seriesService.GetAllSeriesPaths().Any(s => context.PropertyValue.ToString().IsParentPath(s.Value));
+            return !_seriesService.GetAllSeriesPaths().Any(s => value.IsParentPath(s.Value));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesExistsValidator.cs
@@ -1,11 +1,11 @@
-using System;
 using System.Linq;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class SeriesExistsValidator : PropertyValidator
+    public class SeriesExistsValidator<T> : PropertyValidator<T, int>
     {
         private readonly ISeriesService _seriesService;
 
@@ -14,18 +14,18 @@ namespace NzbDrone.Core.Validation.Paths
             _seriesService = seriesService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "This series has already been added";
+        public override string Name => "SeriesExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "This series has already been added";
+
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
-            if (context.PropertyValue == null)
+            if (value == 0)
             {
                 return true;
             }
 
-            var tvdbId = Convert.ToInt32(context.PropertyValue.ToString());
-
-            return !_seriesService.AllSeriesTvdbIds().Any(s => s == tvdbId);
+            return !_seriesService.AllSeriesTvdbIds().Any(s => s == value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -6,7 +7,7 @@ using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class SeriesPathValidator : PropertyValidator
+    public class SeriesPathValidator<T> : PropertyValidator<T, string>
     {
         private readonly ISeriesService _seriesService;
 
@@ -15,24 +16,26 @@ namespace NzbDrone.Core.Validation.Paths
             _seriesService = seriesService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' is already configured for another series";
+        public override string Name => "SeriesPathValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' is already configured for another series";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
-            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("path", value);
 
-            dynamic instance = context.ParentContext.InstanceToValidate;
+            dynamic instance = context.InstanceToValidate;
             var instanceId = (int)instance.Id;
 
-            // Skip the path for this series and any invalid paths
+            // Skip the path for this series and any invalid paths
             return !_seriesService.GetAllSeriesPaths().Any(s => s.Key != instanceId &&
                                                                 s.Value.IsPathValid(PathValidationType.CurrentOs) &&
-                                                                s.Value.PathEquals(context.PropertyValue.ToString()));
+                                                                s.Value.PathEquals(value));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
@@ -1,10 +1,11 @@
-﻿using FluentValidation.Validators;
+using FluentValidation;
+using FluentValidation.Validators;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class StartupFolderValidator : PropertyValidator
+    public class StartupFolderValidator<T> : PropertyValidator<T, string>
     {
         private readonly IAppFolderInfo _appFolderInfo;
 
@@ -13,27 +14,28 @@ namespace NzbDrone.Core.Validation.Paths
             _appFolderInfo = appFolderInfo;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' cannot be {relationship} the start up folder";
+        public override string Name => "StartupFolderValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' cannot be {relationship} the start up folder";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
             var startupFolder = _appFolderInfo.StartUpFolder;
-            var folder = context.PropertyValue.ToString();
-            context.MessageFormatter.AppendArgument("path", folder);
+            context.MessageFormatter.AppendArgument("path", value);
 
-            if (startupFolder.PathEquals(folder))
+            if (startupFolder.PathEquals(value))
             {
                 context.MessageFormatter.AppendArgument("relationship", "set to");
 
                 return false;
             }
 
-            if (startupFolder.IsParentPath(folder))
+            if (startupFolder.IsParentPath(value))
             {
                 context.MessageFormatter.AppendArgument("relationship", "child of");
 

--- a/src/NzbDrone.Core/Validation/Paths/SystemFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SystemFolderValidator.cs
@@ -1,30 +1,32 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Validation.Paths
 {
-    public class SystemFolderValidator : PropertyValidator
+    public class SystemFolderValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Path '{path}' is {relationship} system folder {systemFolder}";
+        public override string Name => "SystemFolderValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Path '{path}' is {relationship} system folder {systemFolder}";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            var folder = context.PropertyValue.ToString();
-            context.MessageFormatter.AppendArgument("path", folder);
+            context.MessageFormatter.AppendArgument("path", value);
 
             foreach (var systemFolder in SystemFolders.GetSystemFolders())
             {
                 context.MessageFormatter.AppendArgument("systemFolder", systemFolder);
 
-                if (systemFolder.PathEquals(folder))
+                if (systemFolder.PathEquals(value))
                 {
                     context.MessageFormatter.AppendArgument("relationship", "set to");
 
                     return false;
                 }
 
-                if (systemFolder.IsParentPath(folder))
+                if (systemFolder.IsParentPath(value))
                 {
                     context.MessageFormatter.AppendArgument("relationship", "child of");
 

--- a/src/NzbDrone.Core/Validation/QualityProfileExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/QualityProfileExistsValidator.cs
@@ -1,9 +1,10 @@
-﻿using FluentValidation.Validators;
+using FluentValidation;
+using FluentValidation.Validators;
 using NzbDrone.Core.Profiles.Qualities;
 
 namespace NzbDrone.Core.Validation
 {
-    public class QualityProfileExistsValidator : PropertyValidator
+    public class QualityProfileExistsValidator<T> : PropertyValidator<T, int>
     {
         private readonly IQualityProfileService _qualityProfileService;
 
@@ -12,16 +13,18 @@ namespace NzbDrone.Core.Validation
             _qualityProfileService = qualityProfileService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Quality Profile does not exist";
+        public override string Name => "QualityProfileExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Quality Profile does not exist";
+
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
-            if (context?.PropertyValue == null || (int)context.PropertyValue == 0)
+            if (value == 0)
             {
                 return true;
             }
 
-            return _qualityProfileService.Exists((int)context.PropertyValue);
+            return _qualityProfileService.Exists(value);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -12,41 +12,41 @@ namespace NzbDrone.Core.Validation
 
         public static IRuleBuilderOptions<T, int> ValidId<T>(this IRuleBuilder<T, int> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new GreaterThanValidator(0));
+            return ruleBuilder.SetValidator(new GreaterThanValidator<T, int>(0));
         }
 
         public static IRuleBuilderOptions<T, int> IsZero<T>(this IRuleBuilder<T, int> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new EqualValidator(0));
+            return ruleBuilder.SetValidator(new EqualValidator<T, int>(0));
         }
 
         public static IRuleBuilderOptions<T, string> HaveHttpProtocol<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new RegularExpressionValidator("^https?://", RegexOptions.IgnoreCase)).WithMessage("must start with http:// or https://");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator<T>("^https?://", RegexOptions.IgnoreCase)).WithMessage("must start with http:// or https://");
         }
 
         public static IRuleBuilderOptions<T, string> ValidHost<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
 
             return ruleBuilder.Must(x => HostRegex.IsMatch(x) || x.IsValidIpAddress()).WithMessage("must be valid Host without http://");
         }
 
         public static IRuleBuilderOptions<T, string> ValidRootUrl<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
 
             return ruleBuilder.Must(x => x.IsValidUrl() && x.StartsWith("http", StringComparison.InvariantCultureIgnoreCase)).WithMessage("must be valid URL that starts with http(s)://");
         }
 
         public static IRuleBuilderOptions<T, string> ValidUrlBase<T>(this IRuleBuilder<T, string> ruleBuilder, string example = "/sonarr")
         {
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(@"^(?!\/?https?://[-_a-z0-9.]+)", RegexOptions.IgnoreCase)).WithMessage($"Must be a valid URL path (ie: '{example}')");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator<T>(@"^(?!\/?https?://[-_a-z0-9.]+)", RegexOptions.IgnoreCase)).WithMessage($"Must be a valid URL path (ie: '{example}')");
         }
 
         public static IRuleBuilderOptions<T, int> ValidPort<T>(this IRuleBuilder<T, int> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new InclusiveBetweenValidator(1, 65535))
+            return ruleBuilder.InclusiveBetween(1, 65535)
                               .Must(x =>
                               {
                                   if (x <= 1024)
@@ -70,8 +70,8 @@ namespace NzbDrone.Core.Validation
 
         public static IRuleBuilderOptions<T, string> StartsOrEndsWithSonarr<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
-            return ruleBuilder.SetValidator(new RegularExpressionValidator("^Sonarr|Sonarr$")).WithMessage("Must start or end with Sonarr");
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, string>());
+            return ruleBuilder.SetValidator(new RegularExpressionValidator<T>("^Sonarr|Sonarr$")).WithMessage("Must start or end with Sonarr");
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/UrlValidator.cs
+++ b/src/NzbDrone.Core/Validation/UrlValidator.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 
@@ -8,24 +8,26 @@ namespace NzbDrone.Core.Validation
     {
         public static IRuleBuilderOptions<T, string> IsValidUrl<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new UrlValidator());
+            return ruleBuilder.SetValidator(new UrlValidator<T>());
         }
     }
 
-    public class UrlValidator : PropertyValidator
+    public class UrlValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid Url: '{url}'";
+        public override string Name => "UrlValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Invalid Url: '{url}'";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }
 
-            context.MessageFormatter.AppendArgument("url", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("url", value);
 
-            return context.PropertyValue.ToString().IsValidUrl();
+            return value.IsValidUrl();
         }
     }
 }

--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
-    <PackageReference Include="FluentValidation" Version="9.5.4" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />

--- a/src/Sonarr.Api.V3/Config/CertificateValidator.cs
+++ b/src/Sonarr.Api.V3/Config/CertificateValidator.cs
@@ -12,19 +12,21 @@ namespace Sonarr.Api.V3.Config
     {
         public static IRuleBuilderOptions<T, string> IsValidCertificate<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new CertificateValidator());
+            return ruleBuilder.SetValidator(new CertificateValidator<T>());
         }
     }
 
-    public class CertificateValidator : PropertyValidator
+    public class CertificateValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid SSL certificate file or {passwordOrKey}. {message}";
+        public override string Name => "CertificateValidator";
 
-        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(CertificateValidator));
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Invalid SSL certificate file or {passwordOrKey}. {message}";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(CertificateValidator<T>));
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }

--- a/src/Sonarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigController.cs
@@ -60,14 +60,14 @@ namespace Sonarr.Api.V3.Config
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .IsValidPath()
-                .SetValidator(new FileExistsValidator(diskProvider))
+                .SetValidator(new FileExistsValidator<HostConfigResource>(diskProvider))
                 .IsValidCertificate()
                 .When(c => c.EnableSsl);
 
             SharedValidator.RuleFor(c => c.SslKeyPath)
                 .NotEmpty()
                 .IsValidPath()
-                .SetValidator(new FileExistsValidator(diskProvider))
+                .SetValidator(new FileExistsValidator<HostConfigResource>(diskProvider))
                 .When(c => c.SslKeyPath.IsNotNullOrWhiteSpace());
 
             SharedValidator.RuleFor(c => c.LogSizeLimit).InclusiveBetween(1, 10);

--- a/src/Sonarr.Api.V3/Config/MediaManagementConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/MediaManagementConfigController.cs
@@ -14,14 +14,14 @@ namespace Sonarr.Api.V3.Config
     public class MediaManagementConfigController : ConfigController<MediaManagementConfigResource>
     {
         public MediaManagementConfigController(IConfigService configService,
-                                           PathExistsValidator pathExistsValidator,
-                                           FolderChmodValidator folderChmodValidator,
-                                           FolderWritableValidator folderWritableValidator,
-                                           SeriesPathValidator seriesPathValidator,
-                                           StartupFolderValidator startupFolderValidator,
-                                           SystemFolderValidator systemFolderValidator,
-                                           RootFolderAncestorValidator rootFolderAncestorValidator,
-                                           RootFolderValidator rootFolderValidator)
+                                           PathExistsValidator<MediaManagementConfigResource> pathExistsValidator,
+                                           FolderChmodValidator<MediaManagementConfigResource> folderChmodValidator,
+                                           FolderWritableValidator<MediaManagementConfigResource> folderWritableValidator,
+                                           SeriesPathValidator<MediaManagementConfigResource> seriesPathValidator,
+                                           StartupFolderValidator<MediaManagementConfigResource> startupFolderValidator,
+                                           SystemFolderValidator<MediaManagementConfigResource> systemFolderValidator,
+                                           RootFolderAncestorValidator<MediaManagementConfigResource> rootFolderAncestorValidator,
+                                           RootFolderValidator<MediaManagementConfigResource> rootFolderValidator)
             : base(configService)
         {
             SharedValidator.RuleFor(c => c.RecycleBinCleanupDays).GreaterThanOrEqualTo(0);

--- a/src/Sonarr.Api.V3/ImportLists/ImportListController.cs
+++ b/src/Sonarr.Api.V3/ImportLists/ImportListController.cs
@@ -15,8 +15,8 @@ namespace Sonarr.Api.V3.ImportLists
 
         public ImportListController(IBroadcastSignalRMessage signalRBroadcaster,
             IImportListFactory importListFactory,
-            RootFolderExistsValidator rootFolderExistsValidator,
-            QualityProfileExistsValidator qualityProfileExistsValidator)
+            RootFolderExistsValidator<ImportListResource> rootFolderExistsValidator,
+            QualityProfileExistsValidator<ImportListResource> qualityProfileExistsValidator)
             : base(signalRBroadcaster, importListFactory, "importlist", ResourceMapper, BulkResourceMapper)
         {
             SharedValidator.RuleFor(c => c.RootFolderPath).Cascade(CascadeMode.Stop)

--- a/src/Sonarr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Sonarr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -18,7 +18,7 @@ namespace Sonarr.Api.V3.ImportLists
         private readonly IImportListExclusionService _importListExclusionService;
 
         public ImportListExclusionController(IImportListExclusionService importListExclusionService,
-                                             ImportListExclusionExistsValidator importListExclusionExistsValidator)
+                                             ImportListExclusionExistsValidator<ImportListExclusionResource> importListExclusionExistsValidator)
         {
             _importListExclusionService = importListExclusionService;
 

--- a/src/Sonarr.Api.V3/ImportLists/ImportListExclusionExistsValidator.cs
+++ b/src/Sonarr.Api.V3/ImportLists/ImportListExclusionExistsValidator.cs
@@ -1,9 +1,10 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Core.ImportLists.Exclusions;
 
 namespace Sonarr.Api.V3.ImportLists
 {
-    public class ImportListExclusionExistsValidator : PropertyValidator
+    public class ImportListExclusionExistsValidator<T> : PropertyValidator<T, int>
     {
         private readonly IImportListExclusionService _importListExclusionService;
 
@@ -12,21 +13,18 @@ namespace Sonarr.Api.V3.ImportLists
             _importListExclusionService = importListExclusionService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "This exclusion has already been added.";
+        public override string Name => "ImportListExclusionExistsValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "This exclusion has already been added.";
+
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
-            if (context.PropertyValue == null)
-            {
-                return true;
-            }
-
             if (context.InstanceToValidate is not ImportListExclusionResource listExclusionResource)
             {
                 return true;
             }
 
-            return !_importListExclusionService.All().Exists(v => v.TvdbId == (int)context.PropertyValue && v.Id != listExclusionResource.Id);
+            return !_importListExclusionService.All().Exists(v => v.TvdbId == value && v.Id != listExclusionResource.Id);
         }
     }
 }

--- a/src/Sonarr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Sonarr.Api.V3/Indexers/IndexerController.cs
@@ -14,7 +14,7 @@ namespace Sonarr.Api.V3.Indexers
 
         public IndexerController(IBroadcastSignalRMessage signalRBroadcaster,
             IndexerFactory indexerFactory,
-            DownloadClientExistsValidator downloadClientExistsValidator)
+            DownloadClientExistsValidator<IndexerResource> downloadClientExistsValidator)
             : base(signalRBroadcaster, indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
         {
             SharedValidator.RuleFor(c => c.Priority).InclusiveBetween(1, 50);

--- a/src/Sonarr.Api.V3/Profiles/Delay/DelayProfileController.cs
+++ b/src/Sonarr.Api.V3/Profiles/Delay/DelayProfileController.cs
@@ -14,7 +14,7 @@ namespace Sonarr.Api.V3.Profiles.Delay
     {
         private readonly IDelayProfileService _delayProfileService;
 
-        public DelayProfileController(IDelayProfileService delayProfileService, DelayProfileTagInUseValidator tagInUseValidator)
+        public DelayProfileController(IDelayProfileService delayProfileService, DelayProfileTagInUseValidator<DelayProfileResource> tagInUseValidator)
         {
             _delayProfileService = delayProfileService;
 

--- a/src/Sonarr.Api.V3/Profiles/Quality/QualityCutoffValidator.cs
+++ b/src/Sonarr.Api.V3/Profiles/Quality/QualityCutoffValidator.cs
@@ -13,14 +13,16 @@ namespace Sonarr.Api.V3.Profiles.Quality
         }
     }
 
-    public class ValidCutoffValidator<T> : PropertyValidator
+    public class ValidCutoffValidator<T> : PropertyValidator<T, int>
     {
-        protected override string GetDefaultMessageTemplate() => "Cutoff must be an allowed quality or group";
+        public override string Name => "ValidCutoffValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Cutoff must be an allowed quality or group";
+
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
-            var cutoff = (int)context.PropertyValue;
-            dynamic instance = context.ParentContext.InstanceToValidate;
+            var cutoff = value;
+            dynamic instance = context.InstanceToValidate;
             var items = instance.Items as IList<QualityProfileQualityItemResource>;
 
             var cutoffItem = items?.SingleOrDefault(i => (i.Quality == null && i.Id == cutoff) || i.Quality?.Id == cutoff);

--- a/src/Sonarr.Api.V3/Profiles/Quality/QualityItemsValidator.cs
+++ b/src/Sonarr.Api.V3/Profiles/Quality/QualityItemsValidator.cs
@@ -10,7 +10,7 @@ namespace Sonarr.Api.V3.Profiles.Quality
     {
         public static IRuleBuilderOptions<T, IList<QualityProfileQualityItemResource>> ValidItems<T>(this IRuleBuilder<T, IList<QualityProfileQualityItemResource>> ruleBuilder)
         {
-            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            ruleBuilder.SetValidator(new NotEmptyValidator<T, IList<QualityProfileQualityItemResource>>());
             ruleBuilder.SetValidator(new AllowedValidator<T>());
             ruleBuilder.SetValidator(new QualityNameValidator<T>());
             ruleBuilder.SetValidator(new GroupItemValidator<T>());
@@ -23,109 +23,122 @@ namespace Sonarr.Api.V3.Profiles.Quality
         }
     }
 
-    public class AllowedValidator<T> : PropertyValidator
+    public class AllowedValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Must contain at least one allowed quality";
+        public override string Name => "AllowedValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain at least one allowed quality";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            return context.PropertyValue is IList<QualityProfileQualityItemResource> list &&
-                   list.Any(c => c.Allowed);
+            return value != null && value.Any(c => c.Allowed);
         }
     }
 
-    public class GroupItemValidator<T> : PropertyValidator
+    public class GroupItemValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Groups must contain multiple qualities";
+        public override string Name => "GroupItemValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must contain multiple qualities";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
-            return !items.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Items.Count <= 1);
+            return !value.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Items.Count <= 1);
         }
     }
 
-    public class QualityNameValidator<T> : PropertyValidator
+    public class QualityNameValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Individual qualities should not be named";
+        public override string Name => "QualityNameValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Individual qualities should not be named";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
-            return !items.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Quality != null);
+            return !value.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Quality != null);
         }
     }
 
-    public class ItemGroupNameValidator<T> : PropertyValidator
+    public class ItemGroupNameValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Groups must have a name";
+        public override string Name => "ItemGroupNameValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must have a name";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
-            return !items.Any(i => i.Quality == null && i.Name.IsNullOrWhiteSpace());
+            return !value.Any(i => i.Quality == null && i.Name.IsNullOrWhiteSpace());
         }
     }
 
-    public class ItemGroupIdValidator<T> : PropertyValidator
+    public class ItemGroupIdValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Groups must have an ID";
+        public override string Name => "ItemGroupIdValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must have an ID";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
-            return !items.Any(i => i.Quality == null && i.Id == 0);
+            return !value.Any(i => i.Quality == null && i.Id == 0);
         }
     }
 
-    public class UniqueIdValidator<T> : PropertyValidator
+    public class UniqueIdValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Groups must have a unique ID";
+        public override string Name => "UniqueIdValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must have a unique ID";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
-            var ids = items.Where(i => i.Id > 0).Select(i => i.Id);
+            var ids = value.Where(i => i.Id > 0).Select(i => i.Id);
             var groupedIds = ids.GroupBy(i => i);
 
             return groupedIds.All(g => g.Count() == 1);
         }
     }
 
-    public class UniqueQualityIdValidator<T> : PropertyValidator
+    public class UniqueQualityIdValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Qualities can only be used once";
+        public override string Name => "UniqueQualityIdValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Qualities can only be used once";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
             var qualityIds = new HashSet<int>();
 
-            foreach (var item in items)
+            foreach (var item in value)
             {
                 if (item.Id > 0)
                 {
@@ -154,20 +167,22 @@ namespace Sonarr.Api.V3.Profiles.Quality
         }
     }
 
-    public class AllQualitiesValidator<T> : PropertyValidator
+    public class AllQualitiesValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
     {
-        protected override string GetDefaultMessageTemplate() => "Must contain all qualities";
+        public override string Name => "AllQualitiesValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain all qualities";
+
+        public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
         {
-            if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+            if (value == null)
             {
                 return false;
             }
 
             var qualityIds = new HashSet<int>();
 
-            foreach (var item in items)
+            foreach (var item in value)
             {
                 if (item.Id > 0)
                 {

--- a/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
@@ -16,8 +16,8 @@ namespace Sonarr.Api.V3.RemotePathMappings
         private readonly IRemotePathMappingService _remotePathMappingService;
 
         public RemotePathMappingController(IRemotePathMappingService remotePathMappingService,
-                                       PathExistsValidator pathExistsValidator,
-                                       MappedNetworkDriveValidator mappedNetworkDriveValidator)
+                                       PathExistsValidator<RemotePathMappingResource> pathExistsValidator,
+                                       MappedNetworkDriveValidator<RemotePathMappingResource> mappedNetworkDriveValidator)
         {
             _remotePathMappingService = remotePathMappingService;
 
@@ -41,7 +41,7 @@ namespace Sonarr.Api.V3.RemotePathMappings
                 .IsValidPath()
                 .SetValidator(mappedNetworkDriveValidator)
                 .SetValidator(pathExistsValidator)
-                .SetValidator(new SystemFolderValidator())
+                .SetValidator(new SystemFolderValidator<RemotePathMappingResource>())
                 .NotEqual("/")
                 .WithMessage("Cannot be set to '/'");
         }

--- a/src/Sonarr.Api.V3/RootFolders/RootFolderController.cs
+++ b/src/Sonarr.Api.V3/RootFolders/RootFolderController.cs
@@ -18,13 +18,13 @@ namespace Sonarr.Api.V3.RootFolders
 
         public RootFolderController(IRootFolderService rootFolderService,
                                 IBroadcastSignalRMessage signalRBroadcaster,
-                                RootFolderValidator rootFolderValidator,
-                                PathExistsValidator pathExistsValidator,
-                                MappedNetworkDriveValidator mappedNetworkDriveValidator,
-                                RecycleBinValidator recycleBinValidator,
-                                StartupFolderValidator startupFolderValidator,
-                                SystemFolderValidator systemFolderValidator,
-                                FolderWritableValidator folderWritableValidator)
+                                RootFolderValidator<RootFolderResource> rootFolderValidator,
+                                PathExistsValidator<RootFolderResource> pathExistsValidator,
+                                MappedNetworkDriveValidator<RootFolderResource> mappedNetworkDriveValidator,
+                                RecycleBinValidator<RootFolderResource> recycleBinValidator,
+                                StartupFolderValidator<RootFolderResource> startupFolderValidator,
+                                SystemFolderValidator<RootFolderResource> systemFolderValidator,
+                                FolderWritableValidator<RootFolderResource> folderWritableValidator)
         : base(signalRBroadcaster)
         {
             _rootFolderService = rootFolderService;

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -57,15 +57,15 @@ namespace Sonarr.Api.V3.Series
                             IManageCommandQueue commandQueueManager,
                             ISeriesDownloadCleanupService seriesDownloadCleanupService,
                             IRootFolderService rootFolderService,
-                            RootFolderValidator rootFolderValidator,
-                            MappedNetworkDriveValidator mappedNetworkDriveValidator,
-                            SeriesPathValidator seriesPathValidator,
-                            SeriesExistsValidator seriesExistsValidator,
-                            SeriesAncestorValidator seriesAncestorValidator,
-                            SystemFolderValidator systemFolderValidator,
-                            QualityProfileExistsValidator qualityProfileExistsValidator,
-                            RootFolderExistsValidator rootFolderExistsValidator,
-                            SeriesFolderAsRootFolderValidator seriesFolderAsRootFolderValidator)
+                            RootFolderValidator<SeriesResource> rootFolderValidator,
+                            MappedNetworkDriveValidator<SeriesResource> mappedNetworkDriveValidator,
+                            SeriesPathValidator<SeriesResource> seriesPathValidator,
+                            SeriesExistsValidator<SeriesResource> seriesExistsValidator,
+                            SeriesAncestorValidator<SeriesResource> seriesAncestorValidator,
+                            SystemFolderValidator<SeriesResource> systemFolderValidator,
+                            QualityProfileExistsValidator<SeriesResource> qualityProfileExistsValidator,
+                            RootFolderExistsValidator<SeriesResource> rootFolderExistsValidator,
+                            SeriesFolderAsRootFolderValidator<SeriesResource> seriesFolderAsRootFolderValidator)
             : base(signalRBroadcaster)
         {
             _seriesService = seriesService;

--- a/src/Sonarr.Api.V3/Series/SeriesEditorValidator.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesEditorValidator.cs
@@ -7,7 +7,7 @@ namespace Sonarr.Api.V3.Series
 {
     public class SeriesEditorValidator : AbstractValidator<NzbDrone.Core.Tv.Series>
     {
-        public SeriesEditorValidator(RootFolderExistsValidator rootFolderExistsValidator, QualityProfileExistsValidator qualityProfileExistsValidator)
+        public SeriesEditorValidator(RootFolderExistsValidator<NzbDrone.Core.Tv.Series> rootFolderExistsValidator, QualityProfileExistsValidator<NzbDrone.Core.Tv.Series> qualityProfileExistsValidator)
         {
             RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
                 .IsValidPath()

--- a/src/Sonarr.Api.V3/Series/SeriesFolderAsRootFolderValidator.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesFolderAsRootFolderValidator.cs
@@ -1,12 +1,13 @@
 using System;
 using System.IO;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Organizer;
 
 namespace Sonarr.Api.V3.Series
 {
-    public class SeriesFolderAsRootFolderValidator : PropertyValidator
+    public class SeriesFolderAsRootFolderValidator<T> : PropertyValidator<T, string>
     {
         private readonly IBuildFileNames _fileNameBuilder;
 
@@ -15,11 +16,13 @@ namespace Sonarr.Api.V3.Series
             _fileNameBuilder = fileNameBuilder;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Root folder path '{rootFolderPath}' contains series folder '{seriesFolder}'";
+        public override string Name => "SeriesFolderAsRootFolderValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Root folder path '{rootFolderPath}' contains series folder '{seriesFolder}'";
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
@@ -29,18 +32,16 @@ namespace Sonarr.Api.V3.Series
                 return true;
             }
 
-            var rootFolderPath = context.PropertyValue.ToString();
-
-            if (rootFolderPath.IsNullOrWhiteSpace())
+            if (value.IsNullOrWhiteSpace())
             {
                 return true;
             }
 
-            var rootFolder = new DirectoryInfo(rootFolderPath!).Name;
+            var rootFolder = new DirectoryInfo(value).Name;
             var series = seriesResource.ToModel();
             var seriesFolder = _fileNameBuilder.GetSeriesFolder(series);
 
-            context.MessageFormatter.AppendArgument("rootFolderPath", rootFolderPath);
+            context.MessageFormatter.AppendArgument("rootFolderPath", value);
             context.MessageFormatter.AppendArgument("seriesFolder", seriesFolder);
 
             if (seriesFolder == rootFolder)

--- a/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
+++ b/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.5.4" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Ical.Net" Version="5.2.2" />
     <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />

--- a/src/Sonarr.Api.V5/ImportLists/ImportListController.cs
+++ b/src/Sonarr.Api.V5/ImportLists/ImportListController.cs
@@ -16,8 +16,8 @@ public class ImportListController : ProviderControllerBase<ImportListResource, I
 
     public ImportListController(IBroadcastSignalRMessage signalRBroadcaster,
         IImportListFactory importListFactory,
-        RootFolderExistsValidator rootFolderExistsValidator,
-        QualityProfileExistsValidator qualityProfileExistsValidator)
+        RootFolderExistsValidator<ImportListResource> rootFolderExistsValidator,
+        QualityProfileExistsValidator<ImportListResource> qualityProfileExistsValidator)
         : base(signalRBroadcaster, importListFactory, "importlist", ResourceMapper, BulkResourceMapper)
     {
         SharedValidator.RuleFor(c => c.RootFolderPath).Cascade(CascadeMode.Stop)

--- a/src/Sonarr.Api.V5/ImportLists/ImportListExclusionController.cs
+++ b/src/Sonarr.Api.V5/ImportLists/ImportListExclusionController.cs
@@ -17,7 +17,7 @@ public class ImportListExclusionController : RestController<ImportListExclusionR
     private readonly IImportListExclusionService _importListExclusionService;
 
     public ImportListExclusionController(IImportListExclusionService importListExclusionService,
-                                         ImportListExclusionExistsValidator importListExclusionExistsValidator)
+                                         ImportListExclusionExistsValidator<ImportListExclusionResource> importListExclusionExistsValidator)
     {
         _importListExclusionService = importListExclusionService;
 

--- a/src/Sonarr.Api.V5/ImportLists/ImportListExclusionExistsValidator.cs
+++ b/src/Sonarr.Api.V5/ImportLists/ImportListExclusionExistsValidator.cs
@@ -1,9 +1,10 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Core.ImportLists.Exclusions;
 
 namespace Sonarr.Api.V5.ImportLists;
 
-public class ImportListExclusionExistsValidator : PropertyValidator
+public class ImportListExclusionExistsValidator<T> : PropertyValidator<T, int>
 {
     private readonly IImportListExclusionService _importListExclusionService;
 
@@ -12,20 +13,17 @@ public class ImportListExclusionExistsValidator : PropertyValidator
         _importListExclusionService = importListExclusionService;
     }
 
-    protected override string GetDefaultMessageTemplate() => "This exclusion has already been added.";
+    public override string Name => "ImportListExclusionExistsValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "This exclusion has already been added.";
+
+    public override bool IsValid(ValidationContext<T> context, int value)
     {
-        if (context.PropertyValue == null)
-        {
-            return true;
-        }
-
         if (context.InstanceToValidate is not ImportListExclusionResource listExclusionResource)
         {
             return true;
         }
 
-        return !_importListExclusionService.All().Exists(v => v.TvdbId == (int)context.PropertyValue && v.Id != listExclusionResource.Id);
+        return !_importListExclusionService.All().Exists(v => v.TvdbId == value && v.Id != listExclusionResource.Id);
     }
 }

--- a/src/Sonarr.Api.V5/Indexers/IndexerController.cs
+++ b/src/Sonarr.Api.V5/Indexers/IndexerController.cs
@@ -15,7 +15,7 @@ public class IndexerController : ProviderControllerBase<IndexerResource, Indexer
 
     public IndexerController(IBroadcastSignalRMessage signalRBroadcaster,
         IndexerFactory indexerFactory,
-        DownloadClientExistsValidator downloadClientExistsValidator)
+        DownloadClientExistsValidator<IndexerResource> downloadClientExistsValidator)
         : base(signalRBroadcaster, indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
     {
         SharedValidator.RuleFor(c => c.Priority).InclusiveBetween(1, 50);

--- a/src/Sonarr.Api.V5/Profiles/Delay/DelayProfileController.cs
+++ b/src/Sonarr.Api.V5/Profiles/Delay/DelayProfileController.cs
@@ -15,7 +15,7 @@ public class DelayProfileController : RestController<DelayProfileResource>
 {
     private readonly IDelayProfileService _delayProfileService;
 
-    public DelayProfileController(IDelayProfileService delayProfileService, DelayProfileTagInUseValidator tagInUseValidator)
+    public DelayProfileController(IDelayProfileService delayProfileService, DelayProfileTagInUseValidator<DelayProfileResource> tagInUseValidator)
     {
         _delayProfileService = delayProfileService;
 

--- a/src/Sonarr.Api.V5/Profiles/Quality/QualityCutoffValidator.cs
+++ b/src/Sonarr.Api.V5/Profiles/Quality/QualityCutoffValidator.cs
@@ -11,14 +11,16 @@ public static class QualityCutoffValidator
     }
 }
 
-public class ValidCutoffValidator<T> : PropertyValidator
+public class ValidCutoffValidator<T> : PropertyValidator<T, int>
 {
-    protected override string GetDefaultMessageTemplate() => "Cutoff must be an allowed quality or group";
+    public override string Name => "ValidCutoffValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Cutoff must be an allowed quality or group";
+
+    public override bool IsValid(ValidationContext<T> context, int value)
     {
-        var cutoff = (int)context.PropertyValue;
-        dynamic instance = context.ParentContext.InstanceToValidate;
+        var cutoff = value;
+        dynamic instance = context.InstanceToValidate!;
         var items = instance.Items as IList<QualityProfileQualityItemResource>;
 
         var cutoffItem = items?.SingleOrDefault(i => (i.Quality == null && i.Id == cutoff) || i.Quality?.Id == cutoff);

--- a/src/Sonarr.Api.V5/Profiles/Quality/QualityItemsValidator.cs
+++ b/src/Sonarr.Api.V5/Profiles/Quality/QualityItemsValidator.cs
@@ -8,7 +8,7 @@ public static class QualityItemsValidator
 {
     public static IRuleBuilderOptions<T, IList<QualityProfileQualityItemResource>> ValidItems<T>(this IRuleBuilder<T, IList<QualityProfileQualityItemResource>> ruleBuilder)
     {
-        ruleBuilder.SetValidator(new NotEmptyValidator(null));
+        ruleBuilder.SetValidator(new NotEmptyValidator<T, IList<QualityProfileQualityItemResource>>());
         ruleBuilder.SetValidator(new AllowedValidator<T>());
         ruleBuilder.SetValidator(new QualityNameValidator<T>());
         ruleBuilder.SetValidator(new GroupItemValidator<T>());
@@ -21,109 +21,122 @@ public static class QualityItemsValidator
     }
 }
 
-public class AllowedValidator<T> : PropertyValidator
+public class AllowedValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Must contain at least one allowed quality";
+    public override string Name => "AllowedValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain at least one allowed quality";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        return context.PropertyValue is IList<QualityProfileQualityItemResource> list &&
-               list.Any(c => c.Allowed);
+        return value != null && value.Any(c => c.Allowed);
     }
 }
 
-public class GroupItemValidator<T> : PropertyValidator
+public class GroupItemValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Groups must contain multiple qualities";
+    public override string Name => "GroupItemValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must contain multiple qualities";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
-        return !items.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Items.Count <= 1);
+        return !value.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Items.Count <= 1);
     }
 }
 
-public class QualityNameValidator<T> : PropertyValidator
+public class QualityNameValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Individual qualities should not be named";
+    public override string Name => "QualityNameValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Individual qualities should not be named";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
-        return !items.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Quality != null);
+        return !value.Any(i => i.Name.IsNotNullOrWhiteSpace() && i.Quality != null);
     }
 }
 
-public class ItemGroupNameValidator<T> : PropertyValidator
+public class ItemGroupNameValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Groups must have a name";
+    public override string Name => "ItemGroupNameValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must have a name";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
-        return !items.Any(i => i.Quality == null && i.Name.IsNullOrWhiteSpace());
+        return !value.Any(i => i.Quality == null && i.Name.IsNullOrWhiteSpace());
     }
 }
 
-public class ItemGroupIdValidator<T> : PropertyValidator
+public class ItemGroupIdValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Groups must have an ID";
+    public override string Name => "ItemGroupIdValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must have an ID";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
-        return !items.Any(i => i.Quality == null && i.Id == 0);
+        return !value.Any(i => i.Quality == null && i.Id == 0);
     }
 }
 
-public class UniqueIdValidator<T> : PropertyValidator
+public class UniqueIdValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Groups must have a unique ID";
+    public override string Name => "UniqueIdValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Groups must have a unique ID";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
-        var ids = items.Where(i => i.Id > 0).Select(i => i.Id);
+        var ids = value.Where(i => i.Id > 0).Select(i => i.Id);
         var groupedIds = ids.GroupBy(i => i);
 
         return groupedIds.All(g => g.Count() == 1);
     }
 }
 
-public class UniqueQualityIdValidator<T> : PropertyValidator
+public class UniqueQualityIdValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Qualities can only be used once";
+    public override string Name => "UniqueQualityIdValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Qualities can only be used once";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
         var qualityIds = new HashSet<int>();
 
-        foreach (var item in items)
+        foreach (var item in value)
         {
             if (item.Id > 0)
             {
@@ -152,20 +165,22 @@ public class UniqueQualityIdValidator<T> : PropertyValidator
     }
 }
 
-public class AllQualitiesValidator<T> : PropertyValidator
+public class AllQualitiesValidator<T> : PropertyValidator<T, IList<QualityProfileQualityItemResource>>
 {
-    protected override string GetDefaultMessageTemplate() => "Must contain all qualities";
+    public override string Name => "AllQualitiesValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Must contain all qualities";
+
+    public override bool IsValid(ValidationContext<T> context, IList<QualityProfileQualityItemResource> value)
     {
-        if (context.PropertyValue is not IList<QualityProfileQualityItemResource> items)
+        if (value == null)
         {
             return false;
         }
 
         var qualityIds = new HashSet<int>();
 
-        foreach (var item in items)
+        foreach (var item in value)
         {
             if (item.Id > 0)
             {

--- a/src/Sonarr.Api.V5/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Sonarr.Api.V5/RemotePathMappings/RemotePathMappingController.cs
@@ -16,8 +16,8 @@ public class RemotePathMappingController : RestController<RemotePathMappingResou
     private readonly IRemotePathMappingService _remotePathMappingService;
 
     public RemotePathMappingController(IRemotePathMappingService remotePathMappingService,
-                                   PathExistsValidator pathExistsValidator,
-                                   MappedNetworkDriveValidator mappedNetworkDriveValidator)
+                                   PathExistsValidator<RemotePathMappingResource> pathExistsValidator,
+                                   MappedNetworkDriveValidator<RemotePathMappingResource> mappedNetworkDriveValidator)
     {
         _remotePathMappingService = remotePathMappingService;
 
@@ -37,7 +37,7 @@ public class RemotePathMappingController : RestController<RemotePathMappingResou
             .IsValidPath()
             .SetValidator(mappedNetworkDriveValidator)
             .SetValidator(pathExistsValidator)
-            .SetValidator(new SystemFolderValidator())
+            .SetValidator(new SystemFolderValidator<RemotePathMappingResource>())
             .NotEqual("/")
             .WithMessage("Cannot be set to '/'");
     }

--- a/src/Sonarr.Api.V5/RootFolders/RootFolderController.cs
+++ b/src/Sonarr.Api.V5/RootFolders/RootFolderController.cs
@@ -19,13 +19,13 @@ public class RootFolderController : RestControllerWithSignalR<RootFolderResource
 
     public RootFolderController(IRootFolderService rootFolderService,
                             IBroadcastSignalRMessage signalRBroadcaster,
-                            RootFolderValidator rootFolderValidator,
-                            PathExistsValidator pathExistsValidator,
-                            MappedNetworkDriveValidator mappedNetworkDriveValidator,
-                            RecycleBinValidator recycleBinValidator,
-                            StartupFolderValidator startupFolderValidator,
-                            SystemFolderValidator systemFolderValidator,
-                            FolderWritableValidator folderWritableValidator)
+                            RootFolderValidator<RootFolderResource> rootFolderValidator,
+                            PathExistsValidator<RootFolderResource> pathExistsValidator,
+                            MappedNetworkDriveValidator<RootFolderResource> mappedNetworkDriveValidator,
+                            RecycleBinValidator<RootFolderResource> recycleBinValidator,
+                            StartupFolderValidator<RootFolderResource> startupFolderValidator,
+                            SystemFolderValidator<RootFolderResource> systemFolderValidator,
+                            FolderWritableValidator<RootFolderResource> folderWritableValidator)
     : base(signalRBroadcaster)
     {
         _rootFolderService = rootFolderService;

--- a/src/Sonarr.Api.V5/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V5/Series/SeriesController.cs
@@ -58,15 +58,15 @@ public class SeriesController : RestControllerWithSignalR<SeriesResource, NzbDro
                         IManageCommandQueue commandQueueManager,
                         ISeriesDownloadCleanupService seriesDownloadCleanupService,
                         IRootFolderService rootFolderService,
-                        RootFolderValidator rootFolderValidator,
-                        MappedNetworkDriveValidator mappedNetworkDriveValidator,
-                        SeriesPathValidator seriesPathValidator,
-                        SeriesExistsValidator seriesExistsValidator,
-                        SeriesAncestorValidator seriesAncestorValidator,
-                        SystemFolderValidator systemFolderValidator,
-                        QualityProfileExistsValidator qualityProfileExistsValidator,
-                        RootFolderExistsValidator rootFolderExistsValidator,
-                        SeriesFolderAsRootFolderValidator seriesFolderAsRootFolderValidator)
+                        RootFolderValidator<SeriesResource> rootFolderValidator,
+                        MappedNetworkDriveValidator<SeriesResource> mappedNetworkDriveValidator,
+                        SeriesPathValidator<SeriesResource> seriesPathValidator,
+                        SeriesExistsValidator<SeriesResource> seriesExistsValidator,
+                        SeriesAncestorValidator<SeriesResource> seriesAncestorValidator,
+                        SystemFolderValidator<SeriesResource> systemFolderValidator,
+                        QualityProfileExistsValidator<SeriesResource> qualityProfileExistsValidator,
+                        RootFolderExistsValidator<SeriesResource> rootFolderExistsValidator,
+                        SeriesFolderAsRootFolderValidator<SeriesResource> seriesFolderAsRootFolderValidator)
         : base(signalRBroadcaster)
     {
         _seriesService = seriesService;

--- a/src/Sonarr.Api.V5/Series/SeriesEditorValidator.cs
+++ b/src/Sonarr.Api.V5/Series/SeriesEditorValidator.cs
@@ -7,7 +7,7 @@ namespace Sonarr.Api.V5.Series;
 
 public class SeriesEditorValidator : AbstractValidator<NzbDrone.Core.Tv.Series>
 {
-    public SeriesEditorValidator(RootFolderExistsValidator rootFolderExistsValidator, QualityProfileExistsValidator qualityProfileExistsValidator)
+    public SeriesEditorValidator(RootFolderExistsValidator<NzbDrone.Core.Tv.Series> rootFolderExistsValidator, QualityProfileExistsValidator<NzbDrone.Core.Tv.Series> qualityProfileExistsValidator)
     {
         RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
             .IsValidPath()

--- a/src/Sonarr.Api.V5/Series/SeriesFolderAsRootFolderValidator.cs
+++ b/src/Sonarr.Api.V5/Series/SeriesFolderAsRootFolderValidator.cs
@@ -1,10 +1,11 @@
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Organizer;
 
 namespace Sonarr.Api.V5.Series;
 
-public class SeriesFolderAsRootFolderValidator : PropertyValidator
+public class SeriesFolderAsRootFolderValidator<T> : PropertyValidator<T, string>
 {
     private readonly IBuildFileNames _fileNameBuilder;
 
@@ -13,11 +14,13 @@ public class SeriesFolderAsRootFolderValidator : PropertyValidator
         _fileNameBuilder = fileNameBuilder;
     }
 
-    protected override string GetDefaultMessageTemplate() => "Root folder path '{rootFolderPath}' contains series folder '{seriesFolder}'";
+    public override string Name => "SeriesFolderAsRootFolderValidator";
 
-    protected override bool IsValid(PropertyValidatorContext context)
+    protected override string GetDefaultMessageTemplate(string errorCode) => "Root folder path '{rootFolderPath}' contains series folder '{seriesFolder}'";
+
+    public override bool IsValid(ValidationContext<T> context, string value)
     {
-        if (context.PropertyValue == null)
+        if (value == null)
         {
             return true;
         }
@@ -27,18 +30,16 @@ public class SeriesFolderAsRootFolderValidator : PropertyValidator
             return true;
         }
 
-        var rootFolderPath = context.PropertyValue.ToString();
-
-        if (rootFolderPath.IsNullOrWhiteSpace())
+        if (value.IsNullOrWhiteSpace())
         {
             return true;
         }
 
-        var rootFolder = new DirectoryInfo(rootFolderPath).Name;
+        var rootFolder = new DirectoryInfo(value).Name;
         var series = seriesResource.ToModel();
         var seriesFolder = _fileNameBuilder.GetSeriesFolder(series);
 
-        context.MessageFormatter.AppendArgument("rootFolderPath", rootFolderPath);
+        context.MessageFormatter.AppendArgument("rootFolderPath", value);
         context.MessageFormatter.AppendArgument("seriesFolder", seriesFolder);
 
         if (seriesFolder == rootFolder)

--- a/src/Sonarr.Api.V5/Settings/CertificateValidator.cs
+++ b/src/Sonarr.Api.V5/Settings/CertificateValidator.cs
@@ -12,19 +12,21 @@ namespace Sonarr.Api.V5.Settings
     {
         public static IRuleBuilderOptions<T, string> IsValidCertificate<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new CertificateValidator());
+            return ruleBuilder.SetValidator(new CertificateValidator<T>());
         }
     }
 
-    public class CertificateValidator : PropertyValidator
+    public class CertificateValidator<T> : PropertyValidator<T, string>
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid SSL certificate file or {passwordOrKey}. {message}";
+        public override string Name => "CertificateValidator";
 
-        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(CertificateValidator));
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Invalid SSL certificate file or {passwordOrKey}. {message}";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(CertificateValidator<T>));
+
+        public override bool IsValid(ValidationContext<T> context, string value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return false;
             }

--- a/src/Sonarr.Api.V5/Settings/GeneralSettingsController.cs
+++ b/src/Sonarr.Api.V5/Settings/GeneralSettingsController.cs
@@ -52,14 +52,14 @@ public class GeneralSettingsController : SettingsController<GeneralSettingsResou
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .IsValidPath()
-            .SetValidator(new FileExistsValidator(diskProvider))
+            .SetValidator(new FileExistsValidator<GeneralSettingsResource>(diskProvider))
             .IsValidCertificate()
             .When(c => c.EnableSsl);
 
         SharedValidator.RuleFor(c => c.SslKeyPath)
             .NotEmpty()
             .IsValidPath()
-            .SetValidator(new FileExistsValidator(diskProvider))
+            .SetValidator(new FileExistsValidator<GeneralSettingsResource>(diskProvider))
             .When(c => c.SslKeyPath.IsNotNullOrWhiteSpace());
 
         SharedValidator.RuleFor(c => c.LogSizeLimit).InclusiveBetween(1, 10);

--- a/src/Sonarr.Api.V5/Settings/MediaManagementSettingsController.cs
+++ b/src/Sonarr.Api.V5/Settings/MediaManagementSettingsController.cs
@@ -13,14 +13,14 @@ public class MediaManagementSettingsController : SettingsController<MediaManagem
 {
     public MediaManagementSettingsController(IConfigFileProvider configFileProvider,
         IConfigService configService,
-        PathExistsValidator pathExistsValidator,
-        FolderChmodValidator folderChmodValidator,
-        FolderWritableValidator folderWritableValidator,
-        SeriesPathValidator seriesPathValidator,
-        StartupFolderValidator startupFolderValidator,
-        SystemFolderValidator systemFolderValidator,
-        RootFolderAncestorValidator rootFolderAncestorValidator,
-        RootFolderValidator rootFolderValidator)
+        PathExistsValidator<MediaManagementSettingsResource> pathExistsValidator,
+        FolderChmodValidator<MediaManagementSettingsResource> folderChmodValidator,
+        FolderWritableValidator<MediaManagementSettingsResource> folderWritableValidator,
+        SeriesPathValidator<MediaManagementSettingsResource> seriesPathValidator,
+        StartupFolderValidator<MediaManagementSettingsResource> startupFolderValidator,
+        SystemFolderValidator<MediaManagementSettingsResource> systemFolderValidator,
+        RootFolderAncestorValidator<MediaManagementSettingsResource> rootFolderAncestorValidator,
+        RootFolderValidator<MediaManagementSettingsResource> rootFolderValidator)
         : base(configFileProvider, configService)
     {
         SharedValidator.RuleFor(c => c.RecycleBinCleanupDays).GreaterThanOrEqualTo(0);

--- a/src/Sonarr.Api.V5/Sonarr.Api.V5.csproj
+++ b/src/Sonarr.Api.V5/Sonarr.Api.V5.csproj
@@ -6,7 +6,7 @@
 		<RootNamespace>Sonarr.Api.V5</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="FluentValidation" Version="9.5.4" />
+		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="Ical.Net" Version="5.2.2" />
 		<PackageReference Include="NLog" Version="5.5.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />

--- a/src/Sonarr.Http/REST/ResourceValidator.cs
+++ b/src/Sonarr.Http/REST/ResourceValidator.cs
@@ -1,9 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentValidation;
-using FluentValidation.Internal;
 using Sonarr.Http.ClientSchema;
 
 namespace Sonarr.Http.REST
@@ -12,17 +11,19 @@ namespace Sonarr.Http.REST
     {
         public IRuleBuilderInitial<TResource, TProperty> RuleForField<TProperty>(Expression<Func<TResource, IEnumerable<Field>>> fieldListAccessor, string fieldName)
         {
-            var rule = new PropertyRule(fieldListAccessor.GetMember(), c => GetValue(c, fieldListAccessor.Compile(), fieldName), null, () => CascadeMode.Continue, typeof(TProperty), typeof(TResource));
-            rule.PropertyName = fieldName;
-            rule.SetDisplayName(fieldName);
+            var accessor = fieldListAccessor.Compile();
+            var builder = RuleFor(resource => (TProperty)GetValue(resource, accessor, fieldName));
 
-            AddRule(rule);
-            return new RuleBuilder<TResource, TProperty>(rule, this);
+            // The value is computed from a field collection rather than a real member, so the
+            // property name has to be set explicitly for validation failures to map to the field.
+            ((IRuleBuilderOptions<TResource, TProperty>)builder).OverridePropertyName(fieldName);
+
+            return builder;
         }
 
-        private static object GetValue(object container, Func<TResource, IEnumerable<Field>> fieldListAccessor, string fieldName)
+        private static object GetValue(TResource container, Func<TResource, IEnumerable<Field>> fieldListAccessor, string fieldName)
         {
-            var resource = fieldListAccessor((TResource)container).SingleOrDefault(c => c.Name == fieldName);
+            var resource = fieldListAccessor(container).SingleOrDefault(c => c.Name == fieldName);
 
             return resource?.Value;
         }

--- a/src/Sonarr.Http/Sonarr.Http.csproj
+++ b/src/Sonarr.Http/Sonarr.Http.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.5.4" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="ImpromptuInterface" Version="8.0.6" />
     <PackageReference Include="MiniProfiler.AspNetCore" Version="4.5.4" />
     <PackageReference Include="NLog" Version="5.5.1" />

--- a/src/Sonarr.Http/Validation/EmptyCollectionValidator.cs
+++ b/src/Sonarr.Http/Validation/EmptyCollectionValidator.cs
@@ -1,21 +1,24 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 
 namespace Sonarr.Http.Validation
 {
-    public class EmptyCollectionValidator<T> : PropertyValidator
+    public class EmptyCollectionValidator<T, TProp> : PropertyValidator<T, IEnumerable<TProp>>
     {
-        protected override string GetDefaultMessageTemplate() => "Collection Must Be Empty";
+        public override string Name => "EmptyCollectionValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Collection Must Be Empty";
+
+        public override bool IsValid(ValidationContext<T> context, IEnumerable<TProp> value)
         {
-            if (context.PropertyValue == null)
+            if (value == null)
             {
                 return true;
             }
 
-            return context.PropertyValue is IEnumerable<T> collection && collection.Empty();
+            return value.Empty();
         }
     }
 }

--- a/src/Sonarr.Http/Validation/RssSyncIntervalValidator.cs
+++ b/src/Sonarr.Http/Validation/RssSyncIntervalValidator.cs
@@ -1,20 +1,16 @@
-﻿using FluentValidation.Validators;
+using FluentValidation;
+using FluentValidation.Validators;
 
 namespace Sonarr.Http.Validation
 {
-    public class RssSyncIntervalValidator : PropertyValidator
+    public class RssSyncIntervalValidator<T> : PropertyValidator<T, int>
     {
-        protected override string GetDefaultMessageTemplate() => "Must be between 10 and 120 or 0 to disable";
+        public override string Name => "RssSyncIntervalValidator";
 
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode) => "Must be between 10 and 120 or 0 to disable";
+
+        public override bool IsValid(ValidationContext<T> context, int value)
         {
-            if (context.PropertyValue == null)
-            {
-                return true;
-            }
-
-            var value = (int)context.PropertyValue;
-
             if (value == 0)
             {
                 return true;

--- a/src/Sonarr.Http/Validation/RuleBuilderExtensions.cs
+++ b/src/Sonarr.Http/Validation/RuleBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Validators;
@@ -9,32 +9,32 @@ namespace Sonarr.Http.Validation
     {
         public static IRuleBuilderOptions<T, int> ValidId<T>(this IRuleBuilder<T, int> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new GreaterThanValidator(0));
+            return ruleBuilder.SetValidator(new GreaterThanValidator<T, int>(0));
         }
 
         public static IRuleBuilderOptions<T, int> IsZero<T>(this IRuleBuilder<T, int> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new EqualValidator(0));
+            return ruleBuilder.SetValidator(new EqualValidator<T, int>(0));
         }
 
         public static IRuleBuilderOptions<T, string> HaveHttpProtocol<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new RegularExpressionValidator("^http(s)?://", RegexOptions.IgnoreCase)).WithMessage("must start with http:// or https://");
+            return ruleBuilder.SetValidator(new RegularExpressionValidator<T>("^http(s)?://", RegexOptions.IgnoreCase)).WithMessage("must start with http:// or https://");
         }
 
         public static IRuleBuilderOptions<T, string> NotBlank<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new NotNullValidator()).SetValidator(new NotEmptyValidator(""));
+            return ruleBuilder.SetValidator(new NotNullValidator<T, string>()).SetValidator(new NotEmptyValidator<T, string>());
         }
 
         public static IRuleBuilderOptions<T, IEnumerable<TProp>> EmptyCollection<T, TProp>(this IRuleBuilder<T, IEnumerable<TProp>> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new EmptyCollectionValidator<TProp>());
+            return ruleBuilder.SetValidator(new EmptyCollectionValidator<T, TProp>());
         }
 
         public static IRuleBuilderOptions<T, int> IsValidRssSyncInterval<T>(this IRuleBuilder<T, int> ruleBuilder)
         {
-            return ruleBuilder.SetValidator(new RssSyncIntervalValidator());
+            return ruleBuilder.SetValidator(new RssSyncIntervalValidator<T>());
         }
     }
 }


### PR DESCRIPTION
Closes #15.

Migrates the validation layer across three major versions (9.5.4 → 12.1.1). v10 made property validators generic in the root type, so essentially all breaking changes land at the 9→10 boundary.

## Changes
- **Version bump** to `12.1.1` in all 5 projects referencing FluentValidation.
- **34 custom validators** → generic `PropertyValidator<T, TProperty>`: new `IsValid(ValidationContext<T>, value)` signature, `GetDefaultMessageTemplate(errorCode)`, `Name` override; `ParentContext.InstanceToValidate` → typed `context.InstanceToValidate`.
- **Built-in validators** → generic constructors in both `RuleBuilderExtensions` files plus `FileNameValidation`/`QualityItems`. `ValidPort` uses the `InclusiveBetween` rule-builder extension since the v12 ctor now needs an `IComparer`.
- **~25 DI injection sites** now inject the closed generic `XxxValidator<TResource>`; DryIoc's `WithAutoConcreteTypeResolution` constructs them.
- **`ResourceValidator.RuleForField`** reimplemented with public API (computed `RuleFor` + `OverridePropertyName`) — v12 made `PropertyRule<,>`/`RuleBuilder<,>` internal. The method had no callers.
- `Custom()`/`RuleForEach` needed no changes (v12 callback/`AddFailure` signatures compile unchanged).

## Context
Upstream Sonarr is still on 9.5.4, so this is novel work that diverges the validation layer from upstream — acceptable since this fork is already decoupled. No CVE drove this; the safety gate is the build + test suite.

## Verification
- Solution builds clean under `TreatWarningsAsErrors`.
- Unit suites: **Core 5127, Api 21, Http 6, Common 591 — 0 failures** (platform-specific tests skipped on the build host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)