### PR TITLE
Replace archived NLog.Targets.Syslog with first-party NLog SyslogTarget

### DIFF
--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NLog" Version="6.1.3" />
     <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.5" />
-    <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
+    <PackageReference Include="NLog.Targets.Network" Version="6.0.4" />
     <PackageReference Include="NLog.Extensions.Logging" Version="6.1.3" />
     <PackageReference Include="Sentry" Version="6.6.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
-using NLog.Targets.Syslog;
-using NLog.Targets.Syslog.Settings;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
@@ -126,15 +124,18 @@ namespace NzbDrone.Core.Instrumentation
 
         private void SetSyslogParameters(string syslogServer, int syslogPort, LogLevel minimumLogLevel)
         {
-            var syslogTarget = new SyslogTarget();
+            var syslogTarget = new SyslogTarget
+            {
+                Name = "syslogTarget",
+                Address = $"udp://{syslogServer}:{syslogPort}",
+                Rfc5424 = true,
+                SyslogAppName = _configFileProvider.InstanceName,
 
-            syslogTarget.Name = "syslogTarget";
-            syslogTarget.MessageSend.Protocol = ProtocolType.Udp;
-            syslogTarget.MessageSend.Udp.Port = syslogPort;
-            syslogTarget.MessageSend.Udp.Server = syslogServer;
-            syslogTarget.MessageSend.Retry.ConstantBackoff.BaseDelay = 500;
-            syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
-            syslogTarget.MessageCreation.Rfc5424.AppName = _configFileProvider.InstanceName;
+                // NLog.Targets.Network defaults to the User facility, whereas the previous
+                // NLog.Targets.Syslog target defaulted to Kernel. Pin it to Kernel so the
+                // facility on the wire stays the same for existing installations.
+                SyslogFacility = NLog.Layouts.SyslogFacility.Kernel
+            };
 
             var loggingRule = new LoggingRule("*", minimumLogLevel, syslogTarget);
 


### PR DESCRIPTION
## Summary

Follow-up to the NLog 6 upgrade (#16). Replaces the archived `NLog.Targets.Syslog` package with the Syslog target that now ships first-party in NLog's own `NLog.Targets.Network`.

**Why:** `NLog.Targets.Syslog` (luigiberrettini) was archived Feb 2025; its latest release (7.0.0) is built against NLog 5. It resolves against NLog 6 via an open `NLog>=5` range and works for our current usage, but it has a latent NLog 6 runtime break in the RFC5424 structured-data (`SdId`) path and will get no further fixes.

## Changes

- **`Sonarr.Common.csproj`**: `NLog.Targets.Syslog 7.0.0` → `NLog.Targets.Network 6.0.4`.
- **`ReconfigureLogging.SetSyslogParameters`**: rewritten against `NLog.Targets.SyslogTarget`.
  - Protocol/host/port fold into the `Address` URI (`udp://host:port`); `Rfc5424` and `SyslogAppName` map directly.
  - The old retry-backoff setting has no equivalent and is irrelevant for UDP fire-and-forget, so it's dropped.
  - **`SyslogFacility` pinned to `Kernel`**: `NLog.Targets.Network` defaults to `User` whereas the old target defaulted to `Kernel`, and we never set it explicitly — pinning keeps the facility on the wire identical for existing installations.

User-facing config keys (`SyslogServer` / `SyslogPort` / `SyslogLevel`) are unchanged.

## Verification

- Solution builds clean (0 warnings / 0 errors) with StyleCop enabled.
- Instrumentation tests pass (90/90).
- End-to-end UDP capture under NLog 6.1.3 produced a valid RFC5424 packet with the Kernel facility and Sonarr app-name:
  `<6>1 <timestamp> <host> Sonarr <pid> - <message>` (`<6>` = Kernel facility 0 + Info severity 6).

## Note for reviewers

The historical **Kernel** facility is preserved for behavior parity. `User` (facility 1) is the technically-correct choice for a userland app (and the new package's default); happy to switch that one line if preferred, accepting that anyone filtering syslog on facility 0 would need to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)